### PR TITLE
Relax strong requirement on atomic mutex acquisition operation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl PerThreadMutex {
         loop {
             if self
                 .futex_word
-                .compare_exchange(0, 1, Ordering::Relaxed, Ordering::Relaxed)
+                .compare_exchange_weak(0, 1, Ordering::Relaxed, Ordering::Relaxed)
                 == Ok(0)
             {
                 let thread_id = unsafe { libc::gettid() } as u32;


### PR DESCRIPTION
https://doc.rust-lang.org/stable/std/sync/atomic/struct.AtomicU32.html#method.compare_exchange_weak

The general consensus seems to be that if the compare_exchange is called in a loop, it is better to use weak because the assembly performs better. Only this invocation was changed because no others are designed to handle spurious failures.