### PR TITLE
Increase GitHub Action checkout version to v6

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run cargo build
       run: cargo build
     - name: Run cargo test


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/834